### PR TITLE
Pin maven plugin versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,14 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.15.0</version>
+                <configuration>
+                    <release>${maven.compiler.release}</release>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <configuration>
                     <archive>


### PR DESCRIPTION
- Fix 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-jar-plugin is missing warning
- No explicit maven-compiler-plugin version was pinned, so Maven can fall back to an old compiler plugin that defaults to source 1.5