### PR TITLE
Pin maven plugin versions, part 2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,13 +99,16 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.15.0</version>
-                <configuration>
-                    <release>${maven.compiler.release}</release>
-                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>3.3.1</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
+                <version>3.5.0</version>
                 <configuration>
                     <archive>
                         <manifestEntries>
@@ -113,6 +116,11 @@
                         </manifestEntries>
                     </archive>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.2.5</version>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
- maven-jar-plugin
- maven-resources-plugin
- maven-surefire-plugin
- Remove <configuration><release> in the compiler plugin. The maven.compiler.release property is already read automatically by the plugin; the explicit config block is noise
